### PR TITLE
Fix typo on OmniFocus URL

### DIFF
--- a/data/apps/omni-foucs.json
+++ b/data/apps/omni-foucs.json
@@ -9,7 +9,7 @@
     {
       "name": "Add",
       "description": "Add a task to OmniFocus",
-      "url": "omnifoucs://x-callback-url/add",
+      "url": "omnifocus://x-callback-url/add",
       "parameters": [
         {
           "name": "name",


### PR DESCRIPTION
I think the first OmniFocus URL is not correct.